### PR TITLE
Tomcat version upgrade

### DIFF
--- a/tomcat-setup/tomcat_manifest.yml
+++ b/tomcat-setup/tomcat_manifest.yml
@@ -1,6 +1,6 @@
 ---
-version: 6.0.26
-download_uri: http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.26/bin/apache-tomcat-6.0.26.tar.gz
+version: 6.0.32
+download_uri: http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.32/bin/apache-tomcat-6.0.32.tar.gz
 
 replace_files: [conf/server.xml, conf/context.xml]
 clear_dirs: [logs, temp, webapps, work]


### PR DESCRIPTION
I've been working with A.B. and Charles Lee to setup a process to keep CloudFoundry and tc Server in sync in terms of the version of Tomcat upon which they depend. As you can see, the process that we've agreed upon is to use pull requests on GitHub.

I've moved the Tomcat version up to the latest-available version of 6.0.x. This is also the version that ships with tc Server.

Let me know if you have any questions.

Thanks,
Andy
