### PR TITLE
Added mongolab support.

### DIFF
--- a/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/CloudEnvironment.java
+++ b/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/CloudEnvironment.java
@@ -58,6 +58,8 @@ public class CloudEnvironment {
 		labelledServiceType(RdbmsServiceInfo.class, "elephantsql-dev");
 		labelledServiceType(RedisServiceInfo.class, "rediscloud");
 		labelledServiceType(RedisServiceInfo.class, "rediscloud-dev");
+		labelledServiceType(MongoServiceInfo.class, "mongolab");
+		labelledServiceType(MongoServiceInfo.class, "mongolab-dev");
 	}
 	
 	/* package for testing purpose */

--- a/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/MongoServiceInfo.java
+++ b/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/MongoServiceInfo.java
@@ -5,11 +5,12 @@ import java.util.Map;
 
 /**
  * Service info for Mongo.
- * 
+ *
  * @author Ramnivas Laddad
- * 
+ *
  */
 public class MongoServiceInfo extends BaseServiceInfo {
+	protected String uri;
 	protected String database;
 	protected String userName;
 
@@ -17,16 +18,21 @@ public class MongoServiceInfo extends BaseServiceInfo {
 		super(serviceInfo);
 		@SuppressWarnings("unchecked")
 		Map<String, Object> credentials =
-			(Map<String, Object>) serviceInfo.get("credentials");
+				(Map<String, Object>) serviceInfo.get("credentials");
+		uri = (String) credentials.get("uri");
 		userName = (String) credentials.get("username");
 		database = (String) credentials.get("db");
 	}
-	
+
 	public String getUserName() {
 		return userName;
 	}
 
 	public String getDatabase() {
 		return database;
+	}
+
+	public String getUri() {
+		return uri;
 	}
 }

--- a/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/env/CloudEnvironmentTest.java
+++ b/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/env/CloudEnvironmentTest.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.runtime.env;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getApplicationInstanceInfo;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getElephantSQLServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getMongoServicePayload;
+import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getMongoLabServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getMysqlServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getPostgreSQLServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRabbitSRSServicePayload;
@@ -78,7 +79,6 @@ public class CloudEnvironmentTest {
 	public void getServiceInfoRedisCloud() {
 		String serviceName = "redis-1";
 
-
 		when(mockEnvironment.getValue("VCAP_SERVICES"))
 			.thenReturn(getServicesPayload(null,
 										   new String[]{getRedisCloudServicePayload(serviceName, hostname, port, password)},
@@ -111,6 +111,22 @@ public class CloudEnvironmentTest {
 			assertEquals(password, info.getPassword());
 			assertEquals(database, info.getDatabase());
 		}
+	}
+
+	@Test
+	public void getServiceInfoMongoLab() {
+		String serviceName = "mongo-1";
+		String database = "mongo-db";
+		String uri = "mongodb://" + username + ":" + password + "@" + hostname + ":" + port + "/" + database;
+
+		when(mockEnvironment.getValue("VCAP_SERVICES"))
+			.thenReturn(getServicesPayload(null,
+										   null,
+										   new String[]{getMongoLabServicePayload(serviceName, hostname, port, username, password, database)},
+										   null));
+		MongoServiceInfo info = testRuntime.getServiceInfo(serviceName, MongoServiceInfo.class);
+		assertEquals(serviceName, info.getServiceName());
+		assertEquals(uri, info.getUri());
 	}
 
 	@Test

--- a/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/service/CloudEnvironmentTestHelper.java
+++ b/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/service/CloudEnvironmentTestHelper.java
@@ -51,6 +51,20 @@ public class CloudEnvironmentTestHelper {
 		return payload;
 	}
 
+	public static String getMongoLabServicePayload(String serviceName,
+			String hostname, int port,
+			String username, String password, String db) {
+		String payload = readTestDataFile("test-mongolab-info.json");
+		payload = payload.replace("$serviceName", serviceName);
+		payload = payload.replace("$hostname", hostname);
+		payload = payload.replace("$port", Integer.toString(port));
+		payload = payload.replace("$username", username);
+		payload = payload.replace("$password", password);
+		payload = payload.replace("$db", db);
+
+		return payload;
+	}
+
 	private static String getRelationalServicePayload(String templateFileName, String version, String serviceName,
 			String hostname, int port,
 			String user, String password, String name) {

--- a/cloudfoundry-runtime/src/test/resources/org/cloudfoundry/runtime/service/test-mongolab-info.json
+++ b/cloudfoundry-runtime/src/test/resources/org/cloudfoundry/runtime/service/test-mongolab-info.json
@@ -1,0 +1,8 @@
+{
+        "name": "$serviceName",
+        "label": "mongolab",
+        "plan": "free",
+        "credentials": {
+            "uri": "mongodb://$username:$password@$hostname:$port/$db"
+        }
+}


### PR DESCRIPTION
Note that when MongoServiceCreator creates the MongoDB connection, it uses the "uri" field from the credentials as-is if the field is present:

`mongoDbFactory = new SimpleMongoDbFactory(new MongoURI(serviceInfo.getUri()));`

This is by request from our MongoDB partner, since they would like to be able to control aspets of the connection using query parameters in the URI if/when necessary. This is reasonable since MongoDB supports connection strings in the form of URIs natively (with the MongoURI class). 
