### PR TITLE
Added the ability to get services by label or name.

### DIFF
--- a/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/CloudEnvironment.java
+++ b/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/CloudEnvironment.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.runtime.env;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -133,7 +134,7 @@ public class CloudEnvironment {
 		return flatServices;
 	}
 	
-	private Map<String, Object> getServiceDataByName(String name) {
+	public Map<String, Object> getServiceDataByName(String name) {
 		List<Map<String, Object>> services = getServices();
 		
 		for (Map<String, Object> service : services) {
@@ -142,6 +143,10 @@ public class CloudEnvironment {
 			}
 		}
 		return null;
+	}
+
+	public List<Map<String, Object>> getServiceDataByLabels(String... labels) {
+		return getServiceDataByLabels(new HashSet<String>(Arrays.asList(labels)));
 	}
 
 	private List<Map<String, Object>> getServiceDataByLabels(Set<String> labels) {

--- a/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/env/CloudEnvironmentTest.java
+++ b/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/env/CloudEnvironmentTest.java
@@ -12,6 +12,7 @@ import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRab
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRdsServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRedisCloudServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRedisServicePayload;
+import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getFullServicesPayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getServicesPayload;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -19,6 +20,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.cloudfoundry.runtime.env.CloudEnvironment.EnvironmentAccessor;
@@ -56,6 +59,47 @@ public class CloudEnvironmentTest {
 
 		when(mockEnvironment.getValue("VCAP_APPLICATION")).thenReturn(getApplicationInstanceInfo("foobar", "foo.cloudfoundry.com"));
 		assertTrue(testRuntime.isCloudFoundry());
+	}
+
+	@Test
+	public void getServiceDataByName_noneFound() {
+		when(mockEnvironment.getValue("VCAP_SERVICES")).thenReturn(getFullServicesPayload());
+
+		Map<String,Object> serviceData = testRuntime.getServiceDataByName("notfound");
+		assertNull(serviceData);
+	}
+
+	@Test
+	public void getServiceDataByName_oneFound() {
+		when(mockEnvironment.getValue("VCAP_SERVICES")).thenReturn(getFullServicesPayload());
+
+		Map<String,Object> serviceData = testRuntime.getServiceDataByName("mongo-3");
+		assertEquals("mongo-3", serviceData.get("name"));
+	}
+
+	@Test
+	public void getServiceDataByLabels_noneFound() {
+		when(mockEnvironment.getValue("VCAP_SERVICES")).thenReturn(getFullServicesPayload());
+
+		List<Map<String, Object>> serviceData = testRuntime.getServiceDataByLabels("notfound");
+		assertEquals(0, serviceData.size());
+	}
+
+	@Test
+	public void getServiceDataByLabels_oneFound() {
+		when(mockEnvironment.getValue("VCAP_SERVICES")).thenReturn(getFullServicesPayload());
+
+		List<Map<String, Object>> serviceData = testRuntime.getServiceDataByLabels("mongodb");
+		assertEquals(1, serviceData.size());
+		assertEquals("mongodb-3.3", serviceData.get(0).get("label"));
+	}
+
+	@Test
+	public void getServiceDataByLabels_multipleFound() {
+		when(mockEnvironment.getValue("VCAP_SERVICES")).thenReturn(getFullServicesPayload());
+
+		List<Map<String, Object>> serviceData = testRuntime.getServiceDataByLabels("mongodb", "redis");
+		assertEquals(2, serviceData.size());
 	}
 
 	@Test

--- a/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/service/CloudEnvironmentTestHelper.java
+++ b/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/service/CloudEnvironmentTestHelper.java
@@ -145,7 +145,14 @@ public class CloudEnvironmentTestHelper {
 		return payload;
 	}
 
-	public static String getServicesPayload(String[] mysqlServicePayloads, 
+	public static String getFullServicesPayload() {
+		return getServicesPayload(new String[]{getMysqlServicePayload("1.1", "mysql-1", "mysql-host", 1111, "mysql-user", "mysql-pass", "database-123")},
+				new String[]{getRedisServicePayload("2.2", "redis-2", "redis-host", 2222, "redis-pass", "r1")},
+				new String[]{getMongoServicePayload("3.3", "mongo-3", "mongo-host", 3333, "mongo-user", "mongo-pass", "db", "name")},
+				new String[]{getRabbitServicePayload("4.4", "rabbit-4", "rabbit-host", 4444, "rabbit-user", "rabbit-pass", "r1", "vhost")});
+	}
+
+	public static String getServicesPayload(String[] mysqlServicePayloads,
 			String[] redisServicePayloads, 
 			String[] mongodbServicePayloads,
 			String[] rabbitServicePayloads) {


### PR DESCRIPTION
For services that do not fit into one of the categories supported by cloudfoundry-runtime, it is necessary for an application to be able to get service info by the services's name or label. 
