### PR TITLE
Create a Play plugin to auto-reconfigure Play apps

### DIFF
--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/Bootstrap.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/Bootstrap.java
@@ -1,12 +1,12 @@
 package org.cloudfoundry.reconfiguration.play;
 
-import org.cloudfoundry.runtime.env.CloudEnvironment;
-
 import play.core.server.NettyServer;
 
 /**
- * Wrapper that takes care of environment initialization and
- * auto-reconfiguration before starting the main Play class.
+ * Wrapper that starts the main Play class.
+ * <p />
+ * Environment initialization and auto-reconfiguration is now handled by PlayPlugin, but this class is retained
+ * to reduce the impact on cloudfoundry-buildpack-java.
  *
  * @author Jennifer Hickey
  *
@@ -14,8 +14,6 @@ import play.core.server.NettyServer;
 public class Bootstrap {
 
 	public static void main(String[] args) {
-		CloudEnvironment environment = new CloudEnvironment();
-		new Configurer(new AppConfiguration(environment), new PropertySetter(environment)).configure();
 		NettyServer.main(args);
 	}
 

--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/PlayPlugin.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/PlayPlugin.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.reconfiguration.play;
+
+import org.cloudfoundry.runtime.env.CloudEnvironment;
+
+import play.*;
+
+/**
+ * The {@link PlayPlugin} class is a Play plugin which overrides a Play
+ * application's configuration in order to reconfigure it for running in
+ * Cloud Foundry.
+ */
+public class PlayPlugin extends Plugin {
+	
+	/**
+	 * Override the application's configuration. This is done statically
+	 * and therefore globally by setting Java system properties.
+	 * 
+	 * @param application the application to be overridden
+	 */
+	public PlayPlugin(Application _) {
+		CloudEnvironment environment = new CloudEnvironment();
+		new Configurer(new AppConfiguration(environment), new PropertySetter(environment)).configure();
+	}
+
+} 

--- a/auto-reconfiguration/src/main/resources/play.plugins
+++ b/auto-reconfiguration/src/main/resources/play.plugins
@@ -1,0 +1,1 @@
+9999:org.cloudfoundry.reconfiguration.play.PlayPlugin


### PR DESCRIPTION
The purpose of this pull request is to reduce the amount of rewriting of the Play start script that the buildpack has to perform. Rather than having the Bootstrap wrapper drive auto-configuration, auto-reconfiguration is moved out to a Play plugin. The wrapper is kept in place, but simply delegates to the NettyServer class. So the buildpack should not need changing as it is free to continue to replace NettyServer with Bootstrap in the startup script.

Please note that I have not been able to test this change as I am having problems adding a database service on Cloud Foundry. Mysql failed to connect with a "User ... has exceeded the 'max_user_connections' resource (current value: 4)" wherease Postgres resulted in an opaque error "Configuration error: Configuration error[Cannot connect to database [default]]". I was attempting to push a trivial Play application and specifying a database service via the interactive options on cf push. Note I was using the current cloudfoundry-buildpack-java with the current level of vcap-java support, so I was nowhere near testing this new code. Any instructions for how to test with a database gratefully received!

[#52912355]
