### PR TITLE
Fixed NPE when binding apps to a user-provided service instance.

### DIFF
--- a/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/CloudEnvironment.java
+++ b/cloudfoundry-runtime/src/main/java/org/cloudfoundry/runtime/env/CloudEnvironment.java
@@ -271,7 +271,9 @@ public class CloudEnvironment {
 	@SuppressWarnings("unchecked")
 	private Properties servicePropertiesHelper(String propertyBase, Map<String, Object> service) {
 		Properties source = new Properties();
-		source.put(propertyBase + ".plan" , service.get("plan").toString());
+		if (service.containsKey("plan")) {
+			source.put(propertyBase + ".plan" , service.get("plan").toString());
+		}
 		source.put(propertyBase + ".type" , service.get("label").toString());
 		for (Entry<String, Object> connectionProperty : ((Map<String, Object>) service.get("credentials")).entrySet()) {
 			source.put(propertyBase + ".connection." + connectionProperty.getKey(), connectionProperty.getValue().toString());

--- a/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/env/CloudEnvironmentTest.java
+++ b/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/env/CloudEnvironmentTest.java
@@ -12,6 +12,7 @@ import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRab
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRdsServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRedisCloudServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getRedisServicePayload;
+import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getUserProvidedServicePayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getFullServicesPayload;
 import static org.cloudfoundry.runtime.service.CloudEnvironmentTestHelper.getServicesPayload;
 import static org.junit.Assert.assertEquals;
@@ -387,6 +388,21 @@ public class CloudEnvironmentTest {
 		assertEquals(cloudProperties.getProperty("cloud.services.mydb.connection.password"), cloudProperties.getProperty("cloud.services.mysql.connection.password"));
 		assertEquals(cloudProperties.getProperty("cloud.services.mydb.connection.name"), cloudProperties.getProperty("cloud.services.mysql.connection.name"));
 		assertEquals(cloudProperties.getProperty("cloud.services.mydb.connection.user"), cloudProperties.getProperty("cloud.services.mysql.connection.user"));
+	}
+
+	@Test
+	public void getCloudProperties_userProvided() {
+		when(mockEnvironment.getValue("VCAP_APPLICATION")).thenReturn(getApplicationInstanceInfo("foo", "foo.cloudfoundry.com"));
+		when(mockEnvironment.getValue("VCAP_SERVICES")).thenReturn(getServicesPayload(
+			new String[]{ getUserProvidedServicePayload("myservice") }
+		));
+
+		Properties cloudProperties = testRuntime.getCloudProperties();
+
+		// service properties by name
+		assertEquals(null, cloudProperties.getProperty("cloud.services.myservice.plan"));
+		assertEquals("user-provided", cloudProperties.getProperty("cloud.services.myservice.type"));
+		assertEquals("userValue", cloudProperties.getProperty("cloud.services.myservice.connection.userKey"));
 	}
 
 	@Test

--- a/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/service/CloudEnvironmentTestHelper.java
+++ b/cloudfoundry-runtime/src/test/java/org/cloudfoundry/runtime/service/CloudEnvironmentTestHelper.java
@@ -76,10 +76,10 @@ public class CloudEnvironmentTestHelper {
 		payload = payload.replace("$user", user);
 		payload = payload.replace("$password", password);
 		payload = payload.replace("$name", name);
-		
+
 		return payload;
 	}
-	
+
 	public static String getMysqlServicePayload(String version, String serviceName,
 			String hostname, int port,
 			String user, String password, String name) {
@@ -145,7 +145,13 @@ public class CloudEnvironmentTestHelper {
 		return payload;
 	}
 
-	public static String getFullServicesPayload() {
+	public static String getUserProvidedServicePayload(String serviceName) {
+		String payload = readTestDataFile("test-user-provided-info.json");
+		payload = payload.replace("$serviceName", serviceName);
+		return payload;
+	}
+
+    public static String getFullServicesPayload() {
 		return getServicesPayload(new String[]{getMysqlServicePayload("1.1", "mysql-1", "mysql-host", 1111, "mysql-user", "mysql-pass", "database-123")},
 				new String[]{getRedisServicePayload("2.2", "redis-2", "redis-host", 2222, "redis-pass", "r1")},
 				new String[]{getMongoServicePayload("3.3", "mongo-3", "mongo-host", 3333, "mongo-user", "mongo-pass", "db", "name")},
@@ -187,6 +193,20 @@ public class CloudEnvironmentTestHelper {
 		}
 		payload.append("}");
 		
+		return payload.toString();
+	}
+
+    public static String getServicesPayload(String[] userProvidedServicePayloads) {
+		StringBuilder payload = new StringBuilder("{");
+		if (userProvidedServicePayloads != null) {
+			if (payload.length() > 1) {
+				payload.append(",");
+			}
+			payload.append("\"user-provided\":");
+			payload.append(getServicePayload(userProvidedServicePayloads));
+		}
+		payload.append("}");
+
 		return payload.toString();
 	}
 	

--- a/cloudfoundry-runtime/src/test/resources/org/cloudfoundry/runtime/service/test-user-provided-info.json
+++ b/cloudfoundry-runtime/src/test/resources/org/cloudfoundry/runtime/service/test-user-provided-info.json
@@ -1,0 +1,7 @@
+{
+        "name": "$serviceName",
+        "label": "user-provided",
+        "credentials": {
+            "userKey": "userValue"
+        }
+}


### PR DESCRIPTION
When a Spring app is bound to a user-provided service instance, the auto-configuration jar will throw a NullPointerException. 

```
ERROR: org.cloudfoundry.reconfiguration.spring.CloudApplicationContextInitializer - Unexpected exception on initialization: null
java.lang.NullPointerException
    at org.cloudfoundry.org.cloudfoundry.runtime.env.CloudEnvironment.servicePropertiesHelper(CloudEnvironment.java:274)
    at org.cloudfoundry.org.cloudfoundry.runtime.env.CloudEnvironment.serviceProperties(CloudEnvironment.java:256)
    at org.cloudfoundry.org.cloudfoundry.runtime.env.CloudEnvironment.getCloudProperties(CloudEnvironment.java:233)
    at org.cloudfoundry.reconfiguration.spring.CloudApplicationContextInitializer.buildPropertySource(CloudApplicationContextInitializer.java:80)
    at org.cloudfoundry.reconfiguration.spring.CloudApplicationContextInitializer.initialize(CloudApplicationContextInitializer.java:66)
    at org.springframework.web.context.ContextLoader.customizeContext(ContextLoader.java:501)
    at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:388)
    at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:294)
    at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:112)
    at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4939)
    at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5434)
    at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
    at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:901)
    at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:877)
    at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:633)
    at org.apache.catalina.startup.HostConfig.deployDirectory(HostConfig.java:1113)
    at org.apache.catalina.startup.HostConfig$DeployDirectory.run(HostConfig.java:1671)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:722)
```

This is due to the fact that user-provided service instances do not have a `plan` attribute in the VCAP_SERVICES json, but code in cloudfoundry-runtime-lib assumes all services have a `plan` attribute. 
