### PR TITLE
Adding info trace to indicate when the reconfiguration actually occured

### DIFF
--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/AbstractCloudServiceBeanFactoryPostProcessor.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/AbstractCloudServiceBeanFactoryPostProcessor.java
@@ -121,6 +121,9 @@ abstract class AbstractCloudServiceBeanFactoryPostProcessor implements
         beanFactory.removeBeanDefinition(beanName);
         beanFactory.registerAlias(getServiceBeanName(), beanName);
 
+        this.logger.info(String.format("Reconfigured bean %s into singleton service connector %s", beanName,
+                serviceConnector.toString()));
+
         return true;
     }
 


### PR DESCRIPTION
Adding info trace to indicate when the reconfiguration actually took place, to make reconfiguration success more explicit (is currently only emitting traces when reconfiguration was failing)

Traces should now appear as:

```
INFO: Trying connector creator type org.springframework.cloud.service.document.MongoDbFactoryCreator@3e19f58c
déc. 02, 2014 6:08:31 PM org.cloudfoundry.reconfiguration.spring.AbstractCloudServiceBeanFactoryPostProcessor reconfigureBean
INFO: Reconfigured bean org.springframework.data.mongodb.core.SimpleMongoDbFactory#0 into singleton service connector org.springframework.data.mongodb.core.SimpleMongoDbFactory@3160c0bd
```
