### PR TITLE
Upgrade Spring Cloud to 1.1.1

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -44,9 +44,16 @@
           <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
           <option name="BLANK_LINES_AFTER_ANONYMOUS_CLASS_HEADER" value="1" />
         </codeStyleSettings>
+        <codeStyleSettings language="JavaScript">
+          <option name="WRAP_COMMENTS" value="true" />
+          <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+        </codeStyleSettings>
+        <codeStyleSettings language="TypeScript">
+          <option name="WRAP_COMMENTS" value="true" />
+          <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+        </codeStyleSettings>
       </value>
     </option>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </component>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <play.version>2.2.2</play.version>
         <spring.version>4.0.3.RELEASE</spring.version>
         <spring-amqp.version>1.3.1.RELEASE</spring-amqp.version>
-        <spring-cloud.version>1.0.0.RELEASE</spring-cloud.version>
+        <spring-cloud.version>1.1.1.RELEASE</spring-cloud.version>
         <spring-data-mongo.version>1.4.1.RELEASE</spring-data-mongo.version>
         <spring-data-redis.version>1.2.1.RELEASE</spring-data-redis.version>
         <servlet-api.version>3.0.1</servlet-api.version>


### PR DESCRIPTION
This commit upgrades the dependency on Spring Cloud to 1.1.1.RELEASE
The fixes a problem with using MongoDB replica in an application.

[resolves #110]
[#84128616]