### PR TITLE
Add CloudProfileApplicationListener and use that for Spring Boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 .idea/sonarqube
 .idea/tasks.xml
 .idea/workspace.xml
+.classpath
+.project
+.settings/
 dependency-reduced-pom.xml
 target

--- a/auto-reconfiguration/pom.xml
+++ b/auto-reconfiguration/pom.xml
@@ -87,6 +87,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId> 
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
             <scope>test</scope>

--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/CloudProfileApplicationContextInitializer.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/CloudProfileApplicationContextInitializer.java
@@ -21,10 +21,6 @@ import org.cloudfoundry.reconfiguration.util.StandardCloudUtils;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.Ordered;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
-
-import java.util.logging.Logger;
 
 /**
  * An {@link ApplicationContextInitializer} implementation that adds the {@code cloud} profile to the collection of of
@@ -34,13 +30,9 @@ import java.util.logging.Logger;
 public final class CloudProfileApplicationContextInitializer implements
         ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
 
-    private static final String CLOUD_PROFILE = "cloud";
-
     private static final int ORDER = 100;
 
-    private final Logger logger = Logger.getLogger(this.getClass().getName());
-
-    private final CloudUtils cloudUtils;
+	private final CloudProfileApplicationListener listener;
 
     /**
      * Creates a new instance
@@ -50,7 +42,7 @@ public final class CloudProfileApplicationContextInitializer implements
     }
 
     CloudProfileApplicationContextInitializer(CloudUtils cloudUtils) {
-        this.cloudUtils = cloudUtils;
+        this.listener = new CloudProfileApplicationListener(cloudUtils);
     }
 
     @Override
@@ -60,31 +52,7 @@ public final class CloudProfileApplicationContextInitializer implements
 
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
-        if (this.cloudUtils.isInCloud()) {
-            addCloudProfile(applicationContext);
-        } else {
-            this.logger.warning("Not running in a cloud. Skipping 'cloud' profile activation.");
-        }
+        listener.addCloudProfile(applicationContext.getEnvironment());
     }
 
-    private void addCloudProfile(ConfigurableApplicationContext applicationContext) {
-        ConfigurableEnvironment environment = applicationContext.getEnvironment();
-
-        if (hasCloudProfile(environment)) {
-            this.logger.fine("'cloud' already in list of active profiles");
-        } else {
-            this.logger.info("Adding 'cloud' to list of active profiles");
-            environment.addActiveProfile(CLOUD_PROFILE);
-        }
-    }
-
-    private boolean hasCloudProfile(Environment environment) {
-        for (String activeProfile : environment.getActiveProfiles()) {
-            if (CLOUD_PROFILE.equalsIgnoreCase(activeProfile)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/CloudProfileApplicationListener.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/CloudProfileApplicationListener.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.cloudfoundry.reconfiguration.spring;
+
+import java.util.logging.Logger;
+
+import org.cloudfoundry.reconfiguration.util.CloudUtils;
+import org.cloudfoundry.reconfiguration.util.StandardCloudUtils;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class CloudProfileApplicationListener implements ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
+
+    private static final String CLOUD_PROFILE = "cloud";
+
+    private static final int ORDER = Ordered.HIGHEST_PRECEDENCE + 3;
+
+    private final Logger logger = Logger.getLogger(this.getClass().getName());
+
+    private final CloudUtils cloudUtils;
+
+    /**
+     * Creates a new instance
+     */
+    public CloudProfileApplicationListener() {
+        this(new StandardCloudUtils());
+    }
+
+    CloudProfileApplicationListener(CloudUtils cloudUtils) {
+        this.cloudUtils = cloudUtils;
+    }
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+    
+    @Override
+    public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
+    	ConfigurableEnvironment environment = event.getEnvironment();
+    	addCloudProfile(environment);
+    }
+
+    void addCloudProfile(ConfigurableEnvironment environment) {
+    	if (this.cloudUtils.isInCloud()) {
+    		if (hasCloudProfile(environment)) {
+    			this.logger.fine("'cloud' already in list of active profiles");
+    		} else {
+    			this.logger.info("Adding 'cloud' to list of active profiles");
+    			environment.addActiveProfile(CLOUD_PROFILE);
+    		}
+        } else {
+            this.logger.warning("Not running in a cloud. Skipping 'cloud' profile activation.");
+        }
+    }
+
+    private boolean hasCloudProfile(Environment environment) {
+        for (String activeProfile : environment.getActiveProfiles()) {
+            if (CLOUD_PROFILE.equalsIgnoreCase(activeProfile)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/auto-reconfiguration/src/main/resources/META-INF/spring.factories
+++ b/auto-reconfiguration/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,7 @@
 # Application Context Initializers
 org.springframework.context.ApplicationContextInitializer=\
-org.cloudfoundry.reconfiguration.spring.CloudProfileApplicationContextInitializer,\
 org.cloudfoundry.reconfiguration.spring.CloudPropertySourceApplicationContextInitializer,\
 org.cloudfoundry.reconfiguration.spring.CloudAutoReconfigurationApplicationContextInitializer
+
+org.springframework.context.ApplicationListener=\
+org.cloudfoundry.reconfiguration.spring.CloudProfileApplicationListener

--- a/auto-reconfiguration/src/test/java/org/cloudfoundry/reconfiguration/spring/CloudProfileApplicationListenerTest.java
+++ b/auto-reconfiguration/src/test/java/org/cloudfoundry/reconfiguration/spring/CloudProfileApplicationListenerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2011-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.cloudfoundry.reconfiguration.spring;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.cloudfoundry.reconfiguration.util.CloudUtils;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+public final class CloudProfileApplicationListenerTest {
+
+	private final CloudUtils cloudUtils = mock(CloudUtils.class);
+
+	private final ConfigurableEnvironment environment = mock(ConfigurableEnvironment.class);
+
+	private final CloudProfileApplicationListener applicationListener = new CloudProfileApplicationListener(
+			this.cloudUtils);
+
+	private ApplicationEnvironmentPreparedEvent event = new ApplicationEnvironmentPreparedEvent(
+			new SpringApplication(), new String[0], environment);
+
+	@Test
+	public void getOrder() {
+		assertEquals(Ordered.HIGHEST_PRECEDENCE + 3, this.applicationListener.getOrder());
+	}
+
+	@Test
+	public void initializeNoCloud() {
+		when(this.cloudUtils.isInCloud()).thenReturn(false);
+
+		this.applicationListener.onApplicationEvent(event);
+
+		verifyZeroInteractions(this.environment);
+	}
+
+	@Test
+	public void initializeAlreadyApplied() {
+		when(this.cloudUtils.isInCloud()).thenReturn(true);
+		when(this.environment.getActiveProfiles()).thenReturn(new String[] { "alpha", "cloud" });
+
+		this.applicationListener.onApplicationEvent(event);
+
+		verify(this.environment, times(0)).addActiveProfile("cloud");
+	}
+
+	@Test
+	public void initialize() {
+		when(this.cloudUtils.isInCloud()).thenReturn(true);
+		when(this.environment.getActiveProfiles()).thenReturn(new String[0]);
+
+		this.applicationListener.onApplicationEvent(event);
+
+		verify(this.environment).addActiveProfile("cloud");
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <play.version>2.2.2</play.version>
         <spring.version>4.0.3.RELEASE</spring.version>
         <spring-amqp.version>1.3.1.RELEASE</spring-amqp.version>
+        <spring-boot.version>1.2.1.RELEASE</spring-boot.version>
         <spring-cloud.version>1.1.1.RELEASE</spring-cloud.version>
         <spring-data-mongo.version>1.4.1.RELEASE</spring-data-mongo.version>
         <spring-data-redis.version>1.2.1.RELEASE</spring-data-redis.version>
@@ -196,6 +197,11 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot</artifactId>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.amqp</groupId>


### PR DESCRIPTION
Instead of using the `CloudProfileApplicationContextInitializer`, which is fine in a container application but comes too late in the lifecycle of a SpringBoot app, we register an `ApplicationListener` to activate the
`cloud` profile.

I suspect that any integration tests that already exist for this feature would also need to be updated, to test that the profile is active in time to read the config files (`application-cloud.properties` for instance).