### PR TITLE
Updated the regexps to pick up on play-slick database configurations

### DIFF
--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfiguration.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfiguration.java
@@ -35,7 +35,10 @@ import java.util.regex.Pattern;
 
 final class StandardApplicationConfiguration implements ApplicationConfiguration {
 
-    private static final Pattern DATABASE_PATTERN = Pattern.compile("db.(.*).driver");
+    private static final Pattern DATABASE_PATTERN = Pattern.compile("db\\.(.*)\\.driver");
+
+    //Matching the driver pattern for play-slick, which is different than the above pattern for regular database stuff
+    private static final Pattern SLICK_DATABASE_PATTERN = Pattern.compile("slick\\.dbs\\.(.*)\\.db\\.driver");
 
     private static final Pattern INCLUDE_PATTERN = Pattern.compile("include \"(.*)\"");
 
@@ -61,8 +64,15 @@ final class StandardApplicationConfiguration implements ApplicationConfiguration
         for (Object key : getConfiguration().keySet()) {
             Matcher matcher = DATABASE_PATTERN.matcher((String) key);
 
+            //also check for slick patterns
+            Matcher slickMatcher = SLICK_DATABASE_PATTERN.matcher((String) key);
+
             if (matcher.find()) {
                 names.add(matcher.group(1));
+            }
+
+            if (slickMatcher.find()) {
+                names.add(slickMatcher.group(1));
             }
         }
 

--- a/auto-reconfiguration/src/test/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfigurationTest.java
+++ b/auto-reconfiguration/src/test/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfigurationTest.java
@@ -89,6 +89,18 @@ public final class StandardApplicationConfigurationTest {
         assertDatabaseNames(this.applicationConfiguration.getDatabaseNames());
     }
 
+    @Test
+    public void getDatabaseNamesSlick() {
+        System.setProperty("config.file", "src/test/resources/play-database-slick.conf");
+        assertDatabaseNames(this.applicationConfiguration.getDatabaseNames(), "default");
+    }
+
+    @Test
+    public void getDatabaseNamesSlickMultiple() {
+        System.setProperty("config.file", "src/test/resources/play-database-slick-multiple.conf");
+        assertDatabaseNames(this.applicationConfiguration.getDatabaseNames(), "default", "another");
+    }
+
     private void assertExpectedKeys(Properties properties, String... keys) {
         assertEquals(keys.length, properties.size());
 

--- a/auto-reconfiguration/src/test/resources/play-database-slick-multiple.conf
+++ b/auto-reconfiguration/src/test/resources/play-database-slick-multiple.conf
@@ -1,0 +1,26 @@
+# Copyright 2011-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+slick.dbs.default.driver = "slick.driver.MySQLDriver$"
+slick.dbs.default.db.driver = org.mariadb.jdbc.Driver
+slick.dbs.default.db.url = "jdbc:mysql://localhost/tracker-app"
+slick.dbs.default.db.user = tracker-app
+slick.dbs.default.db.password = "a strong password"
+
+
+slick.dbs.another.driver = "slick.driver.MySQLDriver$"
+slick.dbs.another.db.driver = org.mariadb.jdbc.Driver
+slick.dbs.another.db.url = "jdbc:mysql://localhost/someotherdb"
+slick.dbs.another.db.user = tracker-app
+slick.dbs.another.db.password = "a strong password"

--- a/auto-reconfiguration/src/test/resources/play-database-slick.conf
+++ b/auto-reconfiguration/src/test/resources/play-database-slick.conf
@@ -1,0 +1,19 @@
+# Copyright 2011-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+slick.dbs.default.driver = "slick.driver.MySQLDriver$"
+slick.dbs.default.db.driver = org.mariadb.jdbc.Driver
+slick.dbs.default.db.url = "jdbc:mysql://localhost/tracker-app"
+slick.dbs.default.db.user = tracker-app
+slick.dbs.default.db.password = "a strong password"


### PR DESCRIPTION
This makes the java-buildpack-auto-reconfiguration work with the newer play-slick stuff. At least, with this, I'll be able to access the system properties again, and I can actually publish my play application to CloudFoundry.

I had to tweak the existing database configuration search to be more precise: It explicitly looks for `.` now. 

Then I added another regexp to use when searching for slick configuration.

Play should barf if trying to use both configurations, so I didn't add any logic to make sure that they were mutually exclusive.