### PR TITLE
Play 2.5.x support

### DIFF
--- a/auto-reconfiguration/pom.xml
+++ b/auto-reconfiguration/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>play_2.10</artifactId>
+            <artifactId>play-server_2.11</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/auto-reconfiguration/pom.xml
+++ b/auto-reconfiguration/pom.xml
@@ -32,6 +32,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <scope>test</scope>

--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/Bootstrap.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/Bootstrap.java
@@ -19,7 +19,7 @@ package org.cloudfoundry.reconfiguration.play;
 import org.cloudfoundry.reconfiguration.util.CloudUtils;
 import org.cloudfoundry.reconfiguration.util.StandardCloudUtils;
 import org.springframework.cloud.Cloud;
-import play.core.server.NettyServer;
+import play.core.server.ProdServerStart;
 
 /**
  * Wrapper that takes care of environment initialization and auto-reconfiguration before starting the main Play
@@ -43,7 +43,8 @@ public final class Bootstrap {
             Configurer.configure(new StandardApplicationConfiguration(), cloud, new StandardPropertySetter(cloud));
         }
 
-        NettyServer.main(args);
+        //In play 2.5.x, you have to start it with ProdServerStart
+        ProdServerStart.main(args);
     }
 
 }

--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfiguration.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfiguration.java
@@ -35,7 +35,10 @@ import java.util.regex.Pattern;
 
 final class StandardApplicationConfiguration implements ApplicationConfiguration {
 
-    private static final Pattern DATABASE_PATTERN = Pattern.compile("db.(.*).driver");
+    private static final Pattern DATABASE_PATTERN = Pattern.compile("db\\.(.*)\\.driver");
+
+    //Matching the driver pattern for play-slick, which is different than the above pattern for regular database stuff
+    private static final Pattern SLICK_DATABASE_PATTERN = Pattern.compile("slick\\.dbs\\.(.*)\\.db\\.driver");
 
     private static final Pattern INCLUDE_PATTERN = Pattern.compile("include \"(.*)\"");
 
@@ -61,8 +64,15 @@ final class StandardApplicationConfiguration implements ApplicationConfiguration
         for (Object key : getConfiguration().keySet()) {
             Matcher matcher = DATABASE_PATTERN.matcher((String) key);
 
+            //also check for slick patterns
+            Matcher slickMatcher = SLICK_DATABASE_PATTERN.matcher((String) key);
+
             if (matcher.find()) {
                 names.add(matcher.group(1));
+            }
+
+            if (slickMatcher.find()) {
+                names.add(slickMatcher.group(1));
             }
         }
 

--- a/auto-reconfiguration/src/test/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfigurationTest.java
+++ b/auto-reconfiguration/src/test/java/org/cloudfoundry/reconfiguration/play/StandardApplicationConfigurationTest.java
@@ -89,6 +89,18 @@ public final class StandardApplicationConfigurationTest {
         assertDatabaseNames(this.applicationConfiguration.getDatabaseNames());
     }
 
+    @Test
+    public void getDatabaseNamesSlick() {
+        System.setProperty("config.file", "src/test/resources/play-database-slick.conf");
+        assertDatabaseNames(this.applicationConfiguration.getDatabaseNames(), "default");
+    }
+
+    @Test
+    public void getDatabaseNamesSlickMultiple() {
+        System.setProperty("config.file", "src/test/resources/play-database-slick-multiple.conf");
+        assertDatabaseNames(this.applicationConfiguration.getDatabaseNames(), "default", "another");
+    }
+
     private void assertExpectedKeys(Properties properties, String... keys) {
         assertEquals(keys.length, properties.size());
 

--- a/auto-reconfiguration/src/test/resources/play-database-slick-multiple.conf
+++ b/auto-reconfiguration/src/test/resources/play-database-slick-multiple.conf
@@ -1,0 +1,26 @@
+# Copyright 2011-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+slick.dbs.default.driver = "slick.driver.MySQLDriver$"
+slick.dbs.default.db.driver = org.mariadb.jdbc.Driver
+slick.dbs.default.db.url = "jdbc:mysql://localhost/tracker-app"
+slick.dbs.default.db.user = tracker-app
+slick.dbs.default.db.password = "a strong password"
+
+
+slick.dbs.another.driver = "slick.driver.MySQLDriver$"
+slick.dbs.another.db.driver = org.mariadb.jdbc.Driver
+slick.dbs.another.db.url = "jdbc:mysql://localhost/someotherdb"
+slick.dbs.another.db.user = tracker-app
+slick.dbs.another.db.password = "a strong password"

--- a/auto-reconfiguration/src/test/resources/play-database-slick.conf
+++ b/auto-reconfiguration/src/test/resources/play-database-slick.conf
@@ -1,0 +1,19 @@
+# Copyright 2011-2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+slick.dbs.default.driver = "slick.driver.MySQLDriver$"
+slick.dbs.default.db.driver = org.mariadb.jdbc.Driver
+slick.dbs.default.db.url = "jdbc:mysql://localhost/tracker-app"
+slick.dbs.default.db.user = tracker-app
+slick.dbs.default.db.password = "a strong password"

--- a/play-jpa-plugin/pom.xml
+++ b/play-jpa-plugin/pom.xml
@@ -33,12 +33,12 @@
     <dependencies>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>play_2.10</artifactId>
+            <artifactId>play-server_2.11</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe.play</groupId>
-            <artifactId>play-java-jpa_2.10</artifactId>
+            <artifactId>play-java-jpa_2.11</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.4.01</version>
+            </dependency>
+            <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>${cglib.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <mariadb.version>1.2.0</mariadb.version>
         <mockito.version>1.10.19</mockito.version>
         <postgresql.version>9.4-1201-jdbc4</postgresql.version>
-        <play.version>2.3.7</play.version>
+        <play.version>2.5.4</play.version>
         <spring.version>4.1.7.RELEASE</spring.version>
         <spring-amqp.version>1.4.5.RELEASE</spring-amqp.version>
         <spring-boot.version>1.2.5.RELEASE</spring-boot.version>
@@ -62,12 +62,12 @@
             </dependency>
             <dependency>
                 <groupId>com.typesafe.play</groupId>
-                <artifactId>play_2.10</artifactId>
+                <artifactId>play-server_2.11</artifactId>
                 <version>${play.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.play</groupId>
-                <artifactId>play-java-jpa_2.10</artifactId>
+                <artifactId>play-java-jpa_2.11</artifactId>
                 <version>${play.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This is a major change to the play support. It will only work with 2.5.x+ (It might work with 2.4.x, I haven't double checked the server api stuff.)

The server API changed and isn't based on NettyServer any longer. Instead you should call the ProdServer object and start it that way. 

This will get support for a play 2.5.x application again on cloud foundry, which will be very helpful. I don't know how to modify this to support multiple versions via configuration....
