### PR TITLE
Lower auto reconfiguration logging level from INFO to FINE. Fixes #61

### DIFF
--- a/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/AbstractCloudServiceBeanFactoryPostProcessor.java
+++ b/auto-reconfiguration/src/main/java/org/cloudfoundry/reconfiguration/spring/AbstractCloudServiceBeanFactoryPostProcessor.java
@@ -121,7 +121,7 @@ abstract class AbstractCloudServiceBeanFactoryPostProcessor implements
         beanFactory.removeBeanDefinition(beanName);
         beanFactory.registerAlias(getServiceBeanName(), beanName);
 
-        this.logger.info(String.format("Reconfigured bean %s into singleton service connector %s", beanName,
+        this.logger.fine(String.format("Reconfigured bean %s into singleton service connector %s", beanName,
                 serviceConnector.toString()));
 
         return true;


### PR DESCRIPTION
Avoids logging data source URLs with userid/password in it (eg: Cloud Foundry CUPS definitions). I could probably check the bean to be of type DataSource and use log level `FINE` only in that scenario. Also could check the bean name itself to be of `dataSource`. Didn't want to complicate things and just turned down the log level. Open to ideas and suggestions.