### PR TITLE
Update spring-cloud-connectors.version to 2.0.4.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-cloud-connectors.version>2.0.3.RELEASE</spring-cloud-connectors.version>
+        <spring-cloud-connectors.version>2.0.4.RELEASE</spring-cloud-connectors.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
To support JDBC drivers that do not support URL decoding, the Spring Cloud Connectors have been updated (see https://github.com/spring-cloud/spring-cloud-connectors/pull/239). This pull request updates the dependency to Spring Cloud Connectors to version 2.0.4.RELEASE to use the bugfix there.