### PR TITLE
Also shade the Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,10 @@
                                     <pattern>org.springframework.cloud</pattern>
                                     <shadedPattern>org.cloudfoundry.reconfiguration.org.springframework.cloud</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.cloudfoundry.reconfiguration.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
                             </relocations>
                             <shadeSourcesContent>true</shadeSourcesContent>
                         </configuration>


### PR DESCRIPTION
To avoid conflicts with Jackson shipped as part of the actual
Cloud Foundry applications.

Fixes #69.